### PR TITLE
Fixed author to center and single line on small devices

### DIFF
--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -8,10 +8,6 @@ img {
     max-width: 100%;
 }
 
-.post-footer .author {
-  margin-right: 100px;
-}
-
 .author {
    font-family: "Open Sans",sans-serif;
    display: inline-block;
@@ -26,7 +22,9 @@ img {
 
   .vcard {
     color: #9EABB3;
+    display: block;
     padding: 10px;
     font-size: 1.5rem;
+    float: left;
   }
 }

--- a/source/_includes/post/author.html
+++ b/source/_includes/post/author.html
@@ -15,8 +15,6 @@
 {% endif %}
 
 {% if author %}
-<div class="author">
   <img src='http://www.gravatar.com/avatar/{{ author_email | md5 }}'/>
-  <span class="byline author vcard">  <span class="fn">{{ author }}</span></span>
-</div>
+  <span class="byline vcard">  <span class="fn">{{ author }}</span></span>
 {% endif %}


### PR DESCRIPTION
@jbaker30 Took some unnecessary styling out to center author name on articles for small screens and prevent it splitting onto multiple lines. Fixes #20.